### PR TITLE
ActiveRecord module for using MuchSlug with ActiveRecord records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'pry', "~> 0.9.0"
+gem "pry", "~> 0.9.0"
+
+# Lock down gem versions because they require a newer version of ruby
+gem 'i18n', "< 0.7"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,28 @@ Friendly, human-readable identifiers for database records.
 
 ## Usage
 
-TODO: Write code samples and usage instructions here
+## Active Record
+
+```ruby
+require "much-slug/activerecord"
+
+class ProjectRecord < ApplicationRecord
+  self.table_name = "projects"
+
+  include MuchSlug::ActiveRecord
+  has_slug({
+    :source       => proc{ "#{self.id}-#{self.abbrev}" },
+    :preprocessor => :upcase
+  })
+  before_update :reset_slug, :if => :abbrev_changed?
+
+  # ...
+end
+```
+
+## Sequel
+
+TODO
 
 ## Installation
 

--- a/lib/much-slug.rb
+++ b/lib/much-slug.rb
@@ -1,4 +1,57 @@
 require "much-slug/version"
+require "much-slug/configs"
+require "much-slug/slug"
 
 module MuchSlug
+
+  def self.default_attribute
+    :slug
+  end
+
+  def self.default_preprocessor
+    :downcase
+  end
+
+  def self.default_separator
+    "-".freeze
+  end
+
+  def self.set_has_slug(configs, options)
+    raise(ArgumentError, "a source must be provided") unless options[:source]
+
+    (options[:attribute] || self.default_attribute).to_sym.tap do |a|
+      configs[a].merge!({
+        :source_proc       => options[:source].to_proc,
+        :preprocessor_proc => (options[:preprocessor] || self.default_preprocessor).to_proc,
+        :separator         => options[:separator] || self.default_separator,
+        :allow_underscores => !!options[:allow_underscores]
+      })
+    end
+  end
+
+  def self.reset_slug(record_instance, attribute)
+    attribute ||= self.default_attribute
+    record_instance.send("#{attribute}=", nil)
+  end
+
+  def self.has_slug_generate_slugs(record_instance)
+     record_instance.class.much_slug_has_slug_configs.each do |attr_name, config|
+      if record_instance.send(attr_name).to_s.empty?
+        slug_source = record_instance.instance_eval(&config[:source_proc])
+      else
+        slug_source = record_instance.send(attr_name)
+      end
+
+      generated_slug = Slug.new(slug_source, {
+        :preprocessor      => config[:preprocessor_proc],
+        :separator         => config[:separator],
+        :allow_underscores => config[:allow_underscores]
+      })
+      next if record_instance.send(attr_name) == generated_slug
+      record_instance.send("#{attr_name}=", generated_slug)
+      yield attr_name, generated_slug
+    end
+
+  end
+
 end

--- a/lib/much-slug/activerecord.rb
+++ b/lib/much-slug/activerecord.rb
@@ -1,0 +1,61 @@
+require "much-plugin"
+require "much-slug"
+
+module MuchSlug
+
+  module ActiveRecord
+    include MuchPlugin
+
+    plugin_included do
+      extend ClassMethods
+      include InstanceMethods
+
+      @much_slug_has_slug_configs = MuchSlug::Configs.new
+    end
+
+    module ClassMethods
+
+      def has_slug(options = nil)
+        options ||= {}
+        attribute = MuchSlug.set_has_slug(@much_slug_has_slug_configs, options)
+
+        # since the slug isn't written until an after callback we can't always
+        # validate presence of it
+        validates_presence_of(attribute, :on => :update)
+
+        if options[:skip_unique_validation] != true
+          validates_uniqueness_of(attribute, {
+            :case_sensitive => true,
+            :scope          => options[:unique_scope]
+          })
+        end
+
+        after_create :much_slug_has_slug_generate_slugs
+        after_update :much_slug_has_slug_generate_slugs
+      end
+
+      def much_slug_has_slug_configs
+        @much_slug_has_slug_configs
+      end
+
+    end
+
+    module InstanceMethods
+
+      private
+
+      def reset_slug(attribute = nil)
+        MuchSlug.reset_slug(self, attribute)
+      end
+
+      def much_slug_has_slug_generate_slugs
+        MuchSlug.has_slug_generate_slugs(self) do |attr_name, generated_slug|
+          self.update_column(attr_name, generated_slug)
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/lib/much-slug/configs.rb
+++ b/lib/much-slug/configs.rb
@@ -1,0 +1,11 @@
+module MuchSlug
+
+  module Configs
+
+    def self.new
+      Hash.new{ |h, k| h[k] = {} }
+    end
+
+  end
+
+end

--- a/lib/much-slug/slug.rb
+++ b/lib/much-slug/slug.rb
@@ -1,0 +1,26 @@
+module MuchSlug
+
+  module Slug
+
+    def self.new(string, options = nil)
+      options ||= {}
+      preprocessor       = options[:preprocessor]
+      separator          = options[:separator]
+      allow_underscores  = options[:allow_underscores]
+      regexp_escaped_sep = Regexp.escape(separator)
+
+      slug = preprocessor.call(string.to_s.dup)
+      # Turn unwanted chars into the separator
+      slug.gsub!(/[^\w#{regexp_escaped_sep}]+/, separator)
+      # Turn underscores into the separator, unless allowing
+      slug.gsub!(/_/, separator) unless allow_underscores
+      # No more than one of the separator in a row.
+      slug.gsub!(/#{regexp_escaped_sep}{2,}/, separator)
+      # Remove leading/trailing separator.
+      slug.gsub!(/\A#{regexp_escaped_sep}|#{regexp_escaped_sep}\z/, "")
+      slug
+    end
+
+  end
+
+end

--- a/much-slug.gemspec
+++ b/much-slug.gemspec
@@ -19,5 +19,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency("assert", ["~> 2.16.5"])
+  gem.add_development_dependency("ardb",   ["~> 0.28.3"])
+
+  gem.add_dependency("much-plugin", ["~> 0.2.0"])
 
 end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,4 +3,13 @@ require 'assert/factory'
 module Factory
   extend Assert::Factory
 
+  def self.non_word_chars
+    ( (" ".."/").to_a +
+      (":".."@").to_a +
+      ("[".."`").to_a +
+      ("{".."~").to_a -
+      ["-", "_"]
+    ).freeze
+  end
+
 end

--- a/test/unit/activerecord_tests.rb
+++ b/test/unit/activerecord_tests.rb
@@ -1,0 +1,238 @@
+require "assert"
+require "much-slug/activerecord"
+
+require "much-plugin"
+require "ardb/record_spy"
+
+module MuchSlug::ActiveRecord
+
+  class UnitTests < Assert::Context
+    desc "MuchSlug::ActiveRecord"
+    setup do
+      source_attribute = @source_attribute = Factory.string.to_sym
+      slug_attribute   = @slug_attribute   = Factory.string.to_sym
+      @record_class = Ardb::RecordSpy.new do
+        include MuchSlug::ActiveRecord
+        attr_accessor source_attribute, slug_attribute, MuchSlug.default_attribute
+        attr_reader :slug_db_column_updates
+
+        def update_column(*args)
+          @slug_db_column_updates ||= []
+          @slug_db_column_updates << args
+        end
+      end
+    end
+    subject{ @record_class }
+
+    should have_imeths :has_slug
+    should have_imeths :much_slug_has_slug_configs
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, MuchSlug::ActiveRecord
+    end
+
+    should "not have any has-slug configs by default" do
+      assert_equal({}, subject.much_slug_has_slug_configs)
+    end
+
+    should "default the has slug config using `has_slug`" do
+      subject.has_slug :source => @source_attribute
+      string = Factory.string
+      record = subject.new.tap{ |r| r.send("#{@source_attribute}=", string) }
+
+      config = subject.much_slug_has_slug_configs[MuchSlug.default_attribute]
+      assert_equal MuchSlug.default_separator, config[:separator]
+      assert_false config[:allow_underscores]
+
+      source_proc = config[:source_proc]
+      assert_instance_of Proc, source_proc
+      exp = record.send(@source_attribute)
+      assert_equal exp, record.instance_eval(&source_proc)
+
+      upcase_string = string.upcase
+      preprocessor_proc = config[:preprocessor_proc]
+      assert_instance_of Proc, preprocessor_proc
+      exp = upcase_string.send(MuchSlug.default_preprocessor)
+      assert_equal exp, preprocessor_proc.call(upcase_string)
+    end
+
+    should "allow customizing the has slug config using `has_slug`" do
+      separator        = Factory.non_word_chars.sample
+      allow_underscore = Factory.boolean
+      subject.has_slug({
+        :attribute         => @slug_attribute,
+        :source            => @source_attribute,
+        :preprocessor      => :upcase,
+        :separator         => separator,
+        :allow_underscores => allow_underscore
+      })
+
+      config = subject.much_slug_has_slug_configs[@slug_attribute]
+      assert_equal separator,        config[:separator]
+      assert_equal allow_underscore, config[:allow_underscores]
+
+      value = Factory.string.downcase
+      preprocessor_proc = config[:preprocessor_proc]
+      assert_instance_of Proc, preprocessor_proc
+      assert_equal value.upcase, preprocessor_proc.call(value)
+    end
+
+    should "add validations using `has_slug`" do
+      subject.has_slug :source => @source_attribute
+      exp_attr_name = MuchSlug.default_attribute
+
+      validation = subject.validations.find{ |v| v.type == :presence }
+      assert_not_nil validation
+      assert_equal [exp_attr_name], validation.columns
+      assert_equal :update, validation.options[:on]
+
+      validation = subject.validations.find{ |v| v.type == :uniqueness }
+      assert_not_nil validation
+      assert_equal [exp_attr_name], validation.columns
+      assert_equal true, validation.options[:case_sensitive]
+      assert_nil validation.options[:scope]
+    end
+
+    should "not add a unique validation if skipping unique validation" do
+      subject.has_slug({
+        :source                 => @source_attribute,
+        :skip_unique_validation => true
+      })
+
+      validation = subject.validations.find{ |v| v.type == :uniqueness }
+      assert_nil validation
+    end
+
+    should "allow customizing its validations using `has_slug`" do
+      unique_scope = Factory.string.to_sym
+      subject.has_slug({
+        :source       => @source_attribute,
+        :unique_scope => unique_scope
+      })
+
+      validation = subject.validations.find{ |v| v.type == :uniqueness }
+      assert_not_nil validation
+      assert_equal unique_scope, validation.options[:scope]
+    end
+
+    should "add callbacks using `has_slug`" do
+      subject.has_slug :source => @source_attribute
+
+      callback = subject.callbacks.find{ |v| v.type == :after_create }
+      assert_not_nil callback
+      assert_equal [:much_slug_has_slug_generate_slugs], callback.args
+
+      callback = subject.callbacks.find{ |v| v.type == :after_update }
+      assert_not_nil callback
+      assert_equal [:much_slug_has_slug_generate_slugs], callback.args
+    end
+
+    should "raise an argument error if `has_slug` isn't passed a source" do
+      assert_raises(ArgumentError){ subject.has_slug }
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @preprocessor      = [:downcase, :upcase, :capitalize].sample
+      @separator         = Factory.non_word_chars.sample
+      @allow_underscores = Factory.boolean
+
+      @record_class.has_slug(:source => @source_attribute)
+      @record_class.has_slug({
+        :attribute         => @slug_attribute,
+        :source            => @source_attribute,
+        :preprocessor      => @preprocessor,
+        :separator         => @separator,
+        :allow_underscores => @allow_underscores,
+      })
+
+      @record = @record_class.new
+
+      # create a string that has mixed case and an underscore so we can test
+      # that it uses the preprocessor and allow underscores options when
+      # generating a slug
+      @source_value = "#{Factory.string.downcase}_#{Factory.string.upcase}"
+      @record.send("#{@source_attribute}=", @source_value)
+
+      @exp_default_slug = MuchSlug::Slug.new(@source_value, {
+        :preprocessor => MuchSlug.default_preprocessor.to_proc,
+        :separator    => MuchSlug.default_separator
+      })
+      @exp_custom_slug = MuchSlug::Slug.new(@source_value, {
+        :preprocessor      => @preprocessor.to_proc,
+        :separator         => @separator,
+        :allow_underscores => @allow_underscores
+      })
+    end
+    subject{ @record }
+
+    should "reset its slug using `reset_slug`" do
+      # reset the default attribute
+      subject.send("#{MuchSlug.default_attribute}=", Factory.slug)
+      assert_not_nil subject.send(MuchSlug.default_attribute)
+      subject.instance_eval{ reset_slug }
+      assert_nil subject.send(MuchSlug.default_attribute)
+
+      # reset a custom attribute
+      subject.send("#{@slug_attribute}=", Factory.slug)
+      assert_not_nil subject.send(@slug_attribute)
+      sa = @slug_attribute
+      subject.instance_eval{ reset_slug(sa) }
+      assert_nil subject.send(@slug_attribute)
+    end
+
+    should "default its slug attribute" do
+      subject.instance_eval{ much_slug_has_slug_generate_slugs }
+      assert_equal 2, subject.slug_db_column_updates.size
+
+      exp = @exp_default_slug
+      assert_equal exp, subject.send(MuchSlug.default_attribute)
+      assert_includes [MuchSlug.default_attribute, exp], subject.slug_db_column_updates
+
+      exp = @exp_custom_slug
+      assert_equal exp, subject.send(@slug_attribute)
+      assert_includes [@slug_attribute, exp], subject.slug_db_column_updates
+    end
+
+    should "not set its slug if it hasn't changed" do
+      @record.send("#{MuchSlug.default_attribute}=", @exp_default_slug)
+      @record.send("#{@slug_attribute}=",   @exp_custom_slug)
+
+      subject.instance_eval{ much_slug_has_slug_generate_slugs }
+      assert_nil subject.slug_db_column_updates
+    end
+
+    should "slug its slug attribute value if set" do
+      @record.send("#{@slug_attribute}=", @source_value)
+      # change the source attr to some random value, to avoid a false positive
+      @record.send("#{@source_attribute}=", Factory.string)
+      subject.instance_eval{ much_slug_has_slug_generate_slugs }
+
+      exp = @exp_custom_slug
+      assert_equal exp, subject.send(@slug_attribute)
+      assert_includes [@slug_attribute, exp], subject.slug_db_column_updates
+    end
+
+    should "slug its source even if its already a valid slug" do
+      slug_source = Factory.slug
+      @record.send("#{@source_attribute}=", slug_source)
+      # ensure the preprocessor doesn't change our source
+      Assert.stub(slug_source, @preprocessor){ slug_source }
+
+      subject.instance_eval{ much_slug_has_slug_generate_slugs }
+
+      exp = MuchSlug::Slug.new(slug_source, {
+        :preprocessor      => @preprocessor.to_proc,
+        :separator         => @separator,
+        :allow_underscores => @allow_underscores
+      })
+      assert_equal exp, subject.send(@slug_attribute)
+      assert_includes [@slug_attribute, exp], subject.slug_db_column_updates
+    end
+
+  end
+
+end

--- a/test/unit/configs_tests.rb
+++ b/test/unit/configs_tests.rb
@@ -1,0 +1,24 @@
+require "assert"
+require "much-slug/configs"
+
+module MuchSlug::Configs
+
+  class UnitTests < Assert::Context
+    desc "MuchSlug::Configs"
+    setup do
+      @module = MuchSlug::Configs
+    end
+    subject{ @module }
+
+    should have_imeths :new
+
+    should "build a new configs hash" do
+      configs = subject.new
+
+      assert_kind_of ::Hash, configs
+      assert_equal ::Hash.new, configs[Factory.string]
+    end
+
+  end
+
+end

--- a/test/unit/much-slug_tests.rb
+++ b/test/unit/much-slug_tests.rb
@@ -1,0 +1,24 @@
+require "assert"
+require "much-slug"
+
+module MuchSlug
+
+  class UnitTests < Assert::Context
+    desc "MuchSlug"
+    setup do
+      @module = MuchSlug
+    end
+    subject{ @module }
+
+    should have_imeths :default_attribute, :default_preprocessor
+    should have_imeths :default_separator
+
+    should "know its default attribute, preprocessor and separator" do
+      assert_equal :slug,     subject.default_attribute
+      assert_equal :downcase, subject.default_preprocessor
+      assert_equal '-',       subject.default_separator
+    end
+
+  end
+
+end

--- a/test/unit/slug_tests.rb
+++ b/test/unit/slug_tests.rb
@@ -1,0 +1,102 @@
+require "assert"
+require "much-slug/slug"
+
+module MuchSlug::Slug
+
+  class UnitTests < Assert::Context
+    desc "MuchSlug::Slug"
+    setup do
+      @no_op_pp = proc{ |slug| slug }
+      @args = {
+        :preprocessor => @no_op_pp,
+        :separator    => "-"
+      }
+
+      @module = MuchSlug::Slug
+    end
+    subject{ @module }
+
+    should have_imeths :new
+
+    should "always dup the given string" do
+      string = Factory.string
+      assert_not_same string, subject.new(string, @args)
+    end
+
+    should "not change strings that are made up of valid chars" do
+      string = Factory.string
+      assert_equal string, subject.new(string, @args)
+
+      string = "#{Factory.string}-#{Factory.string.upcase}"
+      assert_equal string, subject.new(string, @args)
+    end
+
+    should "turn invalid chars into a separator" do
+      string = Factory.integer(3).times.map do
+        "#{Factory.string(3)}#{Factory.non_word_chars.sample}#{Factory.string(3)}"
+      end.join(Factory.non_word_chars.sample)
+      assert_equal string.gsub(/[^\w]+/, "-"), subject.new(string, @args)
+    end
+
+    should "allow passing a custom preprocessor proc" do
+      string = "#{Factory.string}-#{Factory.string.upcase}"
+      exp = string.downcase
+      assert_equal exp, subject.new(string, @args.merge(:preprocessor => :downcase.to_proc))
+
+      preprocessor = proc{ |s| s.gsub(/[A-Z]/, "a") }
+      exp = preprocessor.call(string)
+      assert_equal exp, subject.new(string, @args.merge(:preprocessor => preprocessor))
+    end
+
+    should "allow passing a custom separator" do
+      separator = Factory.non_word_chars.sample
+
+      invalid_char = (Factory.non_word_chars - [separator]).sample
+      string = "#{Factory.string}#{invalid_char}#{Factory.string}"
+      exp = string.gsub(/[^\w]+/, separator)
+      assert_equal exp, subject.new(string, @args.merge(:separator => separator))
+
+      # it won"t change the separator in the strings
+      string = "#{Factory.string}#{separator}#{Factory.string}"
+      exp = string
+      assert_equal string, subject.new(string, @args.merge(:separator => separator))
+
+      # it will change the default separator now
+      string = "#{Factory.string}-#{Factory.string}"
+      exp = string.gsub("-", separator)
+      assert_equal exp, subject.new(string, @args.merge(:separator => separator))
+    end
+
+    should "change underscores into its separator unless allowed" do
+      string = "#{Factory.string}_#{Factory.string}"
+      assert_equal string.gsub("_", "-"), subject.new(string, @args)
+
+      exp = string.gsub("_", "-")
+      assert_equal exp, subject.new(string, @args.merge(:allow_underscores => false))
+
+      assert_equal string, subject.new(string, @args.merge(:allow_underscores => true))
+    end
+
+    should "not allow multiple separators in a row" do
+      string = "#{Factory.string}--#{Factory.string}"
+      assert_equal string.gsub(/-{2,}/, "-"), subject.new(string, @args)
+
+      # remove separators that were added from changing invalid chars
+      invalid_chars = (Factory.integer(3) + 1).times.map{ Factory.non_word_chars.sample }.join
+      string = "#{Factory.string}#{invalid_chars}#{Factory.string}"
+      assert_equal string.gsub(/[^\w]+/, "-"), subject.new(string, @args)
+    end
+
+    should "remove leading and trailing separators" do
+      string = "-#{Factory.string}-#{Factory.string}-"
+      assert_equal string[1..-2], subject.new(string, @args)
+
+      # remove separators that were added from changing invalid chars
+      invalid_char = Factory.non_word_chars.sample
+      string = "#{invalid_char}#{Factory.string}-#{Factory.string}#{invalid_char}"
+      assert_equal string[1..-2], subject.new(string, @args)
+    end
+
+  end
+
+end


### PR DESCRIPTION
This logic is being extracted from Ardb.  Ardb is designed to only
work with ActiveRecord but MuchSlug is more generic and is
theoretically usable with any ORM.  Thus I've broken out all of
the ActiveRecord-specific logic into a MuchSlug::ActiveRecord
mixin and I've commonized the logic that is ORM-agnostic into
singleton methods on the MuchSlug module.  This sets us up to
extend this API for use with Sequel, etc records.

Otherwise all of the logic should be fairly identical to the Ardb
version.  Here are some notes on the things that are different:

* I broke out some of the common logic into their own files since
  we have a fresh namespace here to work with (ie. MuchSlug::Slug).
* I moved the tests `NON_WORD_CHARS` into the Factory since it is
  used across multiple tests files.
* I moved the `DEFAULT_*` constants to singleton methods since they
  are used in multiple files now.
* I don't unit test the non `default_*` methonds in `MuchSlug`, I
  count on the ActiveRecord module tests to test them for me.  So
  the ActiveRecord tests are acting kinda like system tests, FYI.

Note: I plan on using this in the Rails testing app we are building
out.  I'll test this in a more production/live scenario when I
start using this in that app.

Note also: I'm planning on removing `Ardb::HasSlug` and all related
apis from Ardb.  This will be a breaking change for Ardb but I'm
less concerned about the ramifications of this b/c of our new
situation.

@jcredding ready for review.  Compare this with Ardb carefully for me and make sure I didn't introduce any regressions.  Also, are you cool with all of these plans since we haven't had a chance to discuss much yet?  Thanks.