### PR TITLE
rework updating slug values; remove `reset_slug` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,21 @@ Friendly, human-readable identifiers for database records.
 
 ## Usage
 
-## Active Record
+MuchSlug creates derived slug values on database records. Typically this means deriving the slug value from record attributes and syncing/caching that value in a dedicated field on the record.
+
+### ActiveRecord
+
+Given a `:slug` field on a record:
+
+```ruby
+class AddSlugToProjects < ActiveRecord::Migration[5.2]
+  def change
+    add_column(:projects, :slug, :string, index: { unique: true })
+  end
+end
+```
+
+Mix-in `MuchSlug::ActiveRecord` and configure:
 
 ```ruby
 require "much-slug/activerecord"
@@ -13,19 +27,159 @@ class ProjectRecord < ApplicationRecord
   self.table_name = "projects"
 
   include MuchSlug::ActiveRecord
-  has_slug({
-    :source       => proc{ "#{self.id}-#{self.abbrev}" },
-    :preprocessor => :upcase
-  })
-  before_update :reset_slug, :if => :abbrev_changed?
+  has_slug(
+    source: -> { "#{self.id}-#{self.name}" },
+  )
 
   # ...
 end
 ```
 
-## Sequel
+The record will save slug values as it is saved:
 
-TODO
+```ruby
+project = ProjectRecord.last
+project.id   # => 123
+project.name # => "Sprockets 2.0"
+project.slug # => nil
+
+# slug values are updated late-bound after record saves
+project.save
+project.slug # => "123-Sprockets-2-0"
+
+project.name = "Widgets For Me"
+project.slug # => "123-Sprockets-2-0"
+project.save
+project.slug # => "123-Widgets-For-Me"
+
+# new Projects also have their slugs assigned once they are saved
+project = Project.new(name: "Do The Things")
+project.slug # => nil
+project.save!
+project.slug # => "124-Do-The-Things"
+```
+
+### Notes
+
+#### Attribute
+
+By default, the record attribute for a slug is `"slug"`. You can override this when configuring slugs:
+
+```ruby
+require "much-slug/activerecord"
+
+class ProjectRecord < ApplicationRecord
+  self.table_name = "projects"
+
+  include MuchSlug::ActiveRecord
+  has_slug(
+    source: -> { "#{self.id}-#{self.name}" },
+  )
+  has_slug(
+    attribute: :full_slug
+    source:    -> { "#{self.id}-#{self.full_name}" },
+  )
+
+  # ...
+end
+```
+
+#### Preprocessor
+
+By default, MuchSlug doesn't pre-process the slug value source before generating the slug value. You can specify a custom pre-processor by passing any Proc-like object:
+
+```ruby
+require "much-slug/activerecord"
+
+class ProjectRecord < ApplicationRecord
+  self.table_name = "projects"
+
+  include MuchSlug::ActiveRecord
+  has_slug(
+    source:       -> { "#{self.id}-#{self.name}" },
+    preprocessor: :downcase
+  )
+  has_slug(
+    attribute:    :full_slug
+    source:       -> { "#{self.id}-#{self.full_name}" },
+    preprocessor: -> { |source_value| source_value[0..30] }
+  )
+
+  # ...
+end
+```
+
+#### Separator
+
+MuchSlug replaces any non-word characters with a separator. This helps make slugs URL-friendly. By default, MuchSlug uses `"-"` for the separator. You can specify a custom separator value when configuring slugs:
+
+```ruby
+require "much-slug/activerecord"
+
+class ProjectRecord < ApplicationRecord
+  self.table_name = "projects"
+
+  include MuchSlug::ActiveRecord
+  has_slug(
+    source:    -> { "#{self.id}.#{self.name}" },
+    separator: "."
+  )
+
+  # ...
+end
+
+project = ProjectRecord.last
+project.id   # => 123
+project.name # => "Sprockets 2.0"
+project.save
+project.slug # => "123.Sprockets.2.0"
+```
+
+#### Allowing Underscores
+
+By default, MuchSlug doesn't allow underscores in source values and treats them like non-word characters. This means it replaces underscores with the separator. You can override this to allow underscores when configuring slugs:
+
+```ruby
+require "much-slug/activerecord"
+
+class ProjectRecord < ApplicationRecord
+  self.table_name = "projects"
+
+  include MuchSlug::ActiveRecord
+  has_slug(
+    source: -> { "#{self.id}-#{self.name}" }
+  )
+  has_slug(
+    attribute:         :full_slug
+    source:            -> { "#{self.id}-#{self.full_name}" },
+    allow_underscores: true
+
+  # ...
+end
+
+project = ProjectRecord.last
+project.id        # => 123
+project.name      # => "SP_2.0"
+project.full_name # => "Sprockets_2.0"
+project.save
+project.slug      # => "123-SP-2-0"
+project.full_slug # => "123-Sprockets_2-0"
+```
+
+#### Manual Slug Updates
+
+Slugs are updated anytime a record is saved with changes that affect the slug. You can trigger this anytime by just saving the records.
+
+If you want a more explicit, intention revealing way to update the slugs, use `MuchSlug.update_slugs` or `MuchSlug.update_slugs!`:
+
+```ruby
+project = ProjectRecord.last
+project.id   # => 123
+project.name # => "Sprockets 2.0"
+
+MuchSlug.update_slugs(project)
+project.slug # => "123-Sprockets-2-0"
+```
 
 ## Installation
 

--- a/lib/much-slug.rb
+++ b/lib/much-slug.rb
@@ -16,7 +16,7 @@ module MuchSlug
   end
 
   def self.default_allow_underscores
-    true
+    false
   end
 
   def self.update_slugs(record)

--- a/lib/much-slug.rb
+++ b/lib/much-slug.rb
@@ -19,6 +19,14 @@ module MuchSlug
     true
   end
 
+  def self.update_slugs(record)
+    record.send("much_slug_update_slugs")
+  end
+
+  def self.update_slugs!(record)
+    record.send("much_slug_update_slugs!")
+  end
+
   def self.has_slug_changed_slug_values(record_instance)
     record_instance.class.much_slug_has_slug_registry.each do |attribute, entry|
       slug_source_value = record_instance.instance_eval(&entry.source_proc)

--- a/lib/much-slug.rb
+++ b/lib/much-slug.rb
@@ -19,28 +19,19 @@ module MuchSlug
     true
   end
 
-  def self.reset_slug(record_instance, attribute)
-    attribute ||= self.default_attribute
-    record_instance.send("#{attribute}=", nil)
-  end
-
-  def self.has_slug_generate_slugs(record_instance)
+  def self.has_slug_changed_slug_values(record_instance)
     record_instance.class.much_slug_has_slug_registry.each do |attribute, entry|
-      slug_source = record_instance.send(attribute)
-      if slug_source.to_s.empty?
-        slug_source = record_instance.instance_eval(&entry.source_proc)
-      end
+      slug_source_value = record_instance.instance_eval(&entry.source_proc)
 
-      generated_slug =
+      slug_value =
         Slug.new(
-          slug_source,
+          slug_source_value,
           preprocessor:      entry.preprocessor_proc,
           separator:         entry.separator,
           allow_underscores: entry.allow_underscores
         )
-      next if record_instance.send(attribute) == generated_slug
-      record_instance.send("#{attribute}=", generated_slug)
-      yield attribute, generated_slug
+      next if record_instance.send(attribute) == slug_value
+      yield attribute, slug_value
     end
   end
 end

--- a/lib/much-slug/activerecord.rb
+++ b/lib/much-slug/activerecord.rb
@@ -38,8 +38,8 @@ module MuchSlug
           })
         end
 
-        after_create :much_slug_has_slug_generate_slugs
-        after_update :much_slug_has_slug_generate_slugs
+        after_create :much_slug_has_slug_update_slug_values
+        after_update :much_slug_has_slug_update_slug_values
       end
 
       def much_slug_has_slug_registry
@@ -50,13 +50,10 @@ module MuchSlug
     plugin_instance_methods do
       private
 
-      def reset_slug(attribute = nil)
-        MuchSlug.reset_slug(self, attribute)
-      end
-
-      def much_slug_has_slug_generate_slugs
-        MuchSlug.has_slug_generate_slugs(self) do |attr_name, generated_slug|
-          self.update_column(attr_name, generated_slug)
+      def much_slug_has_slug_update_slug_values
+        MuchSlug.has_slug_changed_slug_values(self) do |attribute, slug_value|
+          self.send("#{attribute}=", slug_value)
+          self.update_column(attribute, slug_value)
         end
       end
     end

--- a/lib/much-slug/activerecord.rb
+++ b/lib/much-slug/activerecord.rb
@@ -56,6 +56,14 @@ module MuchSlug
           self.update_column(attribute, slug_value)
         end
       end
+
+      def much_slug_update_slugs
+        self.save
+      end
+
+      def much_slug_update_slugs!
+        self.save!
+      end
     end
   end
 end

--- a/test/unit/activerecord_tests.rb
+++ b/test/unit/activerecord_tests.rb
@@ -107,11 +107,11 @@ module MuchSlug::ActiveRecord
 
       callback = subject.callbacks.find{ |v| v.type == :after_create }
       assert_not_nil callback
-      assert_equal [:much_slug_has_slug_generate_slugs], callback.args
+      assert_equal [:much_slug_has_slug_update_slug_values], callback.args
 
       callback = subject.callbacks.find{ |v| v.type == :after_update }
       assert_not_nil callback
-      assert_equal [:much_slug_has_slug_generate_slugs], callback.args
+      assert_equal [:much_slug_has_slug_update_slug_values], callback.args
     end
 
     should "raise an argument error if `has_slug` isn't passed a source" do
@@ -160,23 +160,8 @@ module MuchSlug::ActiveRecord
     end
     subject{ @record }
 
-    should "reset its slug using `reset_slug`" do
-      # reset the default attribute
-      subject.send("#{MuchSlug.default_attribute}=", Factory.slug)
-      assert_not_nil subject.send(MuchSlug.default_attribute)
-      subject.instance_eval{ reset_slug }
-      assert_nil subject.send(MuchSlug.default_attribute)
-
-      # reset a custom attribute
-      subject.send("#{@slug_attribute}=", Factory.slug)
-      assert_not_nil subject.send(@slug_attribute)
-      sa = @slug_attribute
-      subject.instance_eval{ reset_slug(sa) }
-      assert_nil subject.send(@slug_attribute)
-    end
-
     should "default its slug attribute" do
-      subject.instance_eval{ much_slug_has_slug_generate_slugs }
+      subject.instance_eval{ much_slug_has_slug_update_slug_values }
       assert_equal 2, subject.slug_db_column_updates.size
 
       exp = @exp_default_slug
@@ -192,19 +177,8 @@ module MuchSlug::ActiveRecord
       @record.send("#{MuchSlug.default_attribute}=", @exp_default_slug)
       @record.send("#{@slug_attribute}=",   @exp_custom_slug)
 
-      subject.instance_eval{ much_slug_has_slug_generate_slugs }
+      subject.instance_eval{ much_slug_has_slug_update_slug_values }
       assert_nil subject.slug_db_column_updates
-    end
-
-    should "slug its slug attribute value if set" do
-      @record.send("#{@slug_attribute}=", @source_value)
-      # change the source attr to some random value, to avoid a false positive
-      @record.send("#{@source_attribute}=", Factory.string)
-      subject.instance_eval{ much_slug_has_slug_generate_slugs }
-
-      exp = @exp_custom_slug
-      assert_equal exp, subject.send(@slug_attribute)
-      assert_includes [@slug_attribute, exp], subject.slug_db_column_updates
     end
 
     should "slug its source even if its already a valid slug" do
@@ -213,7 +187,7 @@ module MuchSlug::ActiveRecord
       # ensure the preprocessor doesn't change our source
       Assert.stub(slug_source, @preprocessor){ slug_source }
 
-      subject.instance_eval{ much_slug_has_slug_generate_slugs }
+      subject.instance_eval{ much_slug_has_slug_update_slug_values }
 
       exp =
         MuchSlug::Slug.new(

--- a/test/unit/activerecord_tests.rb
+++ b/test/unit/activerecord_tests.rb
@@ -158,7 +158,7 @@ module MuchSlug::ActiveRecord
           @source_value,
           preprocessor:      MuchSlug.default_preprocessor.to_proc,
           separator:         MuchSlug.default_separator,
-          allow_underscores: true
+          allow_underscores: false
         )
       @exp_custom_slug =
         MuchSlug::Slug.new(

--- a/test/unit/much-slug_tests.rb
+++ b/test/unit/much-slug_tests.rb
@@ -11,6 +11,7 @@ module MuchSlug
 
     should have_imeths :default_attribute, :default_preprocessor
     should have_imeths :default_separator, :default_allow_underscores
+    should have_imeths :update_slugs, :update_slugs!
 
     should "know its default settings" do
       assert_equal "slug", subject.default_attribute

--- a/test/unit/much-slug_tests.rb
+++ b/test/unit/much-slug_tests.rb
@@ -17,7 +17,7 @@ module MuchSlug
       assert_equal "slug", subject.default_attribute
       assert_equal :to_s, subject.default_preprocessor
       assert_equal "-", subject.default_separator
-      assert_equal true, subject.default_allow_underscores
+      assert_equal false, subject.default_allow_underscores
     end
   end
 end


### PR DESCRIPTION
This reworks how MuchSlug updates slug values to keep them in
sync with the source value. Previously, MuchSlug would only update
the slug value if the slug attribute was blank. MuchSlug provided a
`reset_slug` API to make the slug attribute blank and then relied
on its late-bound `after_update` callback to re-sync the slug
value.

This has a number of confusing edge cases:

* you have to remember to use `reset_slug`
* you have to call reset slug in a `before_update` callback or
  something that runs after validation but before `after_update`
* you can't call `reset_slug` before validations b/c the blank
  slug will fail validation

The overall goal is that MuchSlug syncs slug values with their
source in a late-bound way. The sync needs to happen after the
save transaction so that users can use db-generated values (like
IDs) in the slug source.

This switches to always calculating the new slug value and then
only updating the record if the generated value doesn't match the
current value. This removes the need for `reset_slug` and removes
a bunch of edge-case concerns. Now to re-sync a slug, the user
needs only to save the record instance and the late-bound
callbacks will update the slug value only if necessary.

Note: one behavior change with this is that you can no longer
set ad-hoc slug values. The callbacks will always overwrite any
ad-hoc value with the sync'd value from the source. This was a
little-known feature that was never really used anyway.

# Other Changes

### add MuchSlug.update_slugs API

This is just a proxy API to calling `.save` on record instances.
That is how you update slug values on records but this just adds
a friendly, explicit name to the operation. It also provides an
adapter layer in case the logic for updating slugs needs to change.

### switch back to not allowing underscores by default

When writing up a new README with usage example I couldn't justify
this. The goal is to consistently make slug values be URL friendly
and having it replace underscores with the separator feels better
since underscores act as word-barriers.

I think a better long-term solution is to let users configure the
global defaults themselves and not be stuck with whatever base
defaults MuchSlug happens to choose.

### update the README

This enriches the usage examples and uses modern Ruby 2 syntax and
keyword arguments. I especially tried to highlight the default
settings and how they can be overridden.