### PR TITLE
fix issues found when using in a real application

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,7 @@ project.full_slug # => "123-Sprockets_2-0"
 
 #### Manual Slug Updates
 
-Slugs are updated anytime a record is saved with changes that affect the slug. You can trigger this anytime by just saving the records.
-
-If you want a more explicit, intention revealing way to update the slugs, use `MuchSlug.update_slugs` or `MuchSlug.update_slugs!`:
+Slugs are updated anytime a record is saved with changes that affect the slug. If you want an explicit, intention-revealing way to update the slugs manually, use `MuchSlug.update_slugs`:
 
 ```ruby
 project = ProjectRecord.last

--- a/lib/much-slug/activerecord.rb
+++ b/lib/much-slug/activerecord.rb
@@ -40,6 +40,8 @@ module MuchSlug
 
         after_create :much_slug_has_slug_update_slug_values
         after_update :much_slug_has_slug_update_slug_values
+
+        registered_attribute
       end
 
       def much_slug_has_slug_registry
@@ -55,14 +57,6 @@ module MuchSlug
           self.send("#{attribute}=", slug_value)
           self.update_column(attribute, slug_value)
         end
-      end
-
-      def much_slug_update_slugs
-        self.save
-      end
-
-      def much_slug_update_slugs!
-        self.save!
       end
     end
   end

--- a/test/unit/much-slug_tests.rb
+++ b/test/unit/much-slug_tests.rb
@@ -11,7 +11,7 @@ module MuchSlug
 
     should have_imeths :default_attribute, :default_preprocessor
     should have_imeths :default_separator, :default_allow_underscores
-    should have_imeths :update_slugs, :update_slugs!
+    should have_imeths :update_slugs
 
     should "know its default settings" do
       assert_equal "slug", subject.default_attribute


### PR DESCRIPTION
This corrects a number of short-coming in the implementation after
using MuchSlug in an application.

* Have `has_slug` return the attribute that was registered. This
  can be used to then dynamically create scopes for the attribute
  (which is beyond the scope for this gem).
* Switch `MuchSlug.updates_slugs` to just update like the record
  callbacks do. This bypasses any validations which is necessary
  in some cases where the slug has been unset or was never set.
  Plus this matches the normal record implementation which is good.
* Better handle both stabby lambdas and symbol-procs. Due to the
  nature of lambdas vs procs and their argument handling, plus
  the nature of `instance_exec` vs `instance_eval`, you can't just
  eval with one or the other. You have to use `instance_exec` with
  lambdas to bypass their strict argument handling. However you
  can't use `instance_exec` with symbol-procs b/c of an
  ArgumentError that gets raised. This seems like a ruby bug that
  may get resolved in the future but for now I've commented about
  it and updated the unit tests to both have a stabby-lambda
  use-case and a symbol-proc use-case.