### PR TITLE
update uniqueness validation to allow nil/blank

### DIFF
--- a/lib/much-slug/activerecord.rb
+++ b/lib/much-slug/activerecord.rb
@@ -34,7 +34,9 @@ module MuchSlug
         unless skip_unique_validation
           validates_uniqueness_of(registered_attribute, {
             :case_sensitive => true,
-            :scope          => unique_scope
+            :scope          => unique_scope,
+            :allow_nil      => true,
+            :allow_blank    => true
           })
         end
 

--- a/test/unit/activerecord_tests.rb
+++ b/test/unit/activerecord_tests.rb
@@ -77,6 +77,8 @@ module MuchSlug::ActiveRecord
       assert_equal [exp_attr_name], validation.columns
       assert_equal true, validation.options[:case_sensitive]
       assert_nil validation.options[:scope]
+      assert_equal true, validation.options[:allow_nil]
+      assert_equal true, validation.options[:allow_blank]
     end
 
     should "not add a unique validation if skipping unique validation" do


### PR DESCRIPTION
From a co-worker:

> nobody cares that the blank value is non-unique when it can't be
  blank in the first place