### PR TITLE
Automatically require `MuchSlug::ActiveRecord` mixin 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ MuchSlug creates derived slug values on database records. Typically this means d
 Given a `:slug` field on a record:
 
 ```ruby
-class AddSlugToProjects < ActiveRecord::Migration[5.2]
+class AddSlugToProjects < ActiveRecord::Migration[6.1]
   def change
     add_column(:projects, :slug, :string, index: { unique: true })
   end
@@ -21,14 +21,12 @@ end
 Mix-in `MuchSlug::ActiveRecord` and configure:
 
 ```ruby
-require "much-slug/activerecord"
-
 class ProjectRecord < ApplicationRecord
   self.table_name = "projects"
 
   include MuchSlug::ActiveRecord
   has_slug(
-    source: -> { "#{self.id}-#{self.name}" },
+    source: -> { "#{id}-#{name}" },
   )
 
   # ...
@@ -66,18 +64,16 @@ project.slug # => "124-Do-The-Things"
 By default, the record attribute for a slug is `"slug"`. You can override this when configuring slugs:
 
 ```ruby
-require "much-slug/activerecord"
-
 class ProjectRecord < ApplicationRecord
   self.table_name = "projects"
 
   include MuchSlug::ActiveRecord
   has_slug(
-    source: -> { "#{self.id}-#{self.name}" },
+    source: -> { "#{id}-#{name}" },
   )
   has_slug(
     attribute: :full_slug
-    source:    -> { "#{self.id}-#{self.full_name}" },
+    source:    -> { "#{id}-#{full_name}" },
   )
 
   # ...
@@ -89,19 +85,17 @@ end
 By default, MuchSlug doesn't pre-process the slug value source before generating the slug value. You can specify a custom pre-processor by passing any Proc-like object:
 
 ```ruby
-require "much-slug/activerecord"
-
 class ProjectRecord < ApplicationRecord
   self.table_name = "projects"
 
   include MuchSlug::ActiveRecord
   has_slug(
-    source:       -> { "#{self.id}-#{self.name}" },
+    source:       -> { "#{id}-#{name}" },
     preprocessor: :downcase
   )
   has_slug(
     attribute:    :full_slug
-    source:       -> { "#{self.id}-#{self.full_name}" },
+    source:       -> { "#{id}-#{full_name}" },
     preprocessor: -> { |source_value| source_value[0..30] }
   )
 
@@ -114,14 +108,12 @@ end
 MuchSlug replaces any non-word characters with a separator. This helps make slugs URL-friendly. By default, MuchSlug uses `"-"` for the separator. You can specify a custom separator value when configuring slugs:
 
 ```ruby
-require "much-slug/activerecord"
-
 class ProjectRecord < ApplicationRecord
   self.table_name = "projects"
 
   include MuchSlug::ActiveRecord
   has_slug(
-    source:    -> { "#{self.id}.#{self.name}" },
+    source:    -> { "#{id}.#{name}" },
     separator: "."
   )
 
@@ -140,18 +132,16 @@ project.slug # => "123.Sprockets.2.0"
 By default, MuchSlug doesn't allow underscores in source values and treats them like non-word characters. This means it replaces underscores with the separator. You can override this to allow underscores when configuring slugs:
 
 ```ruby
-require "much-slug/activerecord"
-
 class ProjectRecord < ApplicationRecord
   self.table_name = "projects"
 
   include MuchSlug::ActiveRecord
   has_slug(
-    source: -> { "#{self.id}-#{self.name}" }
+    source: -> { "#{id}-#{name}" }
   )
   has_slug(
     attribute:         :full_slug
-    source:            -> { "#{self.id}-#{self.full_name}" },
+    source:            -> { "#{id}-#{full_name}" },
     allow_underscores: true
 
   # ...

--- a/lib/much-slug.rb
+++ b/lib/much-slug.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-require "much-slug/version"
+require "much-slug/activerecord"
 require "much-slug/has_slug_registry"
 require "much-slug/slug"
+require "much-slug/version"
 
 module MuchSlug
   def self.default_attribute
@@ -14,7 +15,7 @@ module MuchSlug
   end
 
   def self.default_separator
-    "-".freeze
+    "-"
   end
 
   def self.default_allow_underscores
@@ -26,8 +27,8 @@ module MuchSlug
     true
   end
 
-  def self.has_slug_changed_slug_values(record_instance)
-    record_instance.class.much_slug_has_slug_registry.each do |attribute, entry|
+  def self.has_slug_changed_slug_values(record)
+    record.class.much_slug_has_slug_registry.each do |attribute, entry|
       # ArgumentError: no receiver given` raised when calling `instance_exec`
       # on non-lambda Procs, specifically e.g :downcase.to_proc.
       # Can't call `instance_eval` on stabby lambdas b/c `instance_eval` auto
@@ -35,9 +36,9 @@ module MuchSlug
       # lambdas may not expect that and will ArgumentError.
       slug_source_value =
         if entry.source_proc.lambda?
-          record_instance.instance_exec(&entry.source_proc)
+          record.instance_exec(&entry.source_proc)
         else
-          record_instance.instance_eval(&entry.source_proc)
+          record.instance_eval(&entry.source_proc)
         end
 
       slug_value =
@@ -47,7 +48,7 @@ module MuchSlug
           separator:         entry.separator,
           allow_underscores: entry.allow_underscores
         )
-      next if record_instance.send(attribute) == slug_value
+      next if record.public_send(attribute) == slug_value
       yield attribute, slug_value
     end
   end

--- a/lib/much-slug/activerecord.rb
+++ b/lib/much-slug/activerecord.rb
@@ -3,61 +3,61 @@
 require "much-mixin"
 require "much-slug"
 
-module MuchSlug
-  module ActiveRecord
-    include MuchMixin
+module MuchSlug; end
 
-    mixin_class_methods do
-      def much_slug_has_slug_registry
-        @much_slug_has_slug_registry ||= MuchSlug::HasSlugRegistry.new
-      end
+module MuchSlug::ActiveRecord
+  include MuchMixin
 
-      def has_slug(
-            source:,
-            attribute:              nil,
-            preprocessor:           nil,
-            separator:              nil,
-            allow_underscores:      nil,
-            skip_unique_validation: false,
-            unique_scope:           nil)
-        registered_attribute =
-          much_slug_has_slug_registry.register(
-            attribute:         attribute,
-            source:            source,
-            preprocessor:      preprocessor,
-            separator:         separator,
-            allow_underscores: allow_underscores,
-          )
-
-        # since the slug isn't written until an after callback we can't always
-        # validate presence of it
-        validates_presence_of(registered_attribute, on: :update)
-
-        unless skip_unique_validation
-          validates_uniqueness_of(
-            registered_attribute,
-            case_sensitive: true,
-            scope:          unique_scope,
-            allow_nil:      true,
-            allow_blank:    true
-          )
-        end
-
-        after_create :much_slug_has_slug_update_slug_values
-        after_update :much_slug_has_slug_update_slug_values
-
-        registered_attribute
-      end
+  mixin_class_methods do
+    def much_slug_has_slug_registry
+      @much_slug_has_slug_registry ||= MuchSlug::HasSlugRegistry.new
     end
 
-    mixin_instance_methods do
-      private
+    def has_slug(
+          source:,
+          attribute:              nil,
+          preprocessor:           nil,
+          separator:              nil,
+          allow_underscores:      nil,
+          skip_unique_validation: false,
+          unique_scope:           nil)
+      registered_attribute =
+        much_slug_has_slug_registry.register(
+          attribute:         attribute,
+          source:            source,
+          preprocessor:      preprocessor,
+          separator:         separator,
+          allow_underscores: allow_underscores,
+        )
 
-      def much_slug_has_slug_update_slug_values
-        MuchSlug.has_slug_changed_slug_values(self) do |attribute, slug_value|
-          public_send("#{attribute}=", slug_value)
-          update_column(attribute, slug_value)
-        end
+      # since the slug isn't written until an after callback we can't always
+      # validate presence of it
+      validates_presence_of(registered_attribute, on: :update)
+
+      unless skip_unique_validation
+        validates_uniqueness_of(
+          registered_attribute,
+          case_sensitive: true,
+          scope:          unique_scope,
+          allow_nil:      true,
+          allow_blank:    true
+        )
+      end
+
+      after_create :much_slug_has_slug_update_slug_values
+      after_update :much_slug_has_slug_update_slug_values
+
+      registered_attribute
+    end
+  end
+
+  mixin_instance_methods do
+    private
+
+    def much_slug_has_slug_update_slug_values
+      MuchSlug.has_slug_changed_slug_values(self) do |attribute, slug_value|
+        public_send("#{attribute}=", slug_value)
+        update_column(attribute, slug_value)
       end
     end
   end

--- a/lib/much-slug/has_slug_registry.rb
+++ b/lib/much-slug/has_slug_registry.rb
@@ -2,44 +2,44 @@
 
 require "much-slug"
 
-module MuchSlug
-  class HasSlugRegistry < ::Hash
-    def initialize
-      super{ |h, k| h[k] = Entry.new }
-    end
+module MuchSlug; end
 
-    def register(
-          attribute:,
-          source:,
-          preprocessor:,
-          separator:,
-          allow_underscores:)
-      attribute         = (attribute || MuchSlug.default_attribute).to_s
-      source_proc       = source.to_proc
-      preprocessor_proc = (preprocessor || MuchSlug.default_preprocessor).to_proc
-      separator         = separator || MuchSlug.default_separator
-      allow_underscores =
-        if allow_underscores.nil?
-          MuchSlug.default_allow_underscores
-        else
-          !!allow_underscores
-        end
-
-      entry = self[attribute]
-      entry.source_proc       = source_proc
-      entry.preprocessor_proc = preprocessor_proc
-      entry.separator         = separator
-      entry.allow_underscores = allow_underscores
-
-      attribute
-    end
-
-    Entry =
-      Struct.new(
-        :source_proc,
-        :preprocessor_proc,
-        :separator,
-        :allow_underscores
-      )
+class MuchSlug::HasSlugRegistry < ::Hash
+  def initialize
+    super{ |h, k| h[k] = Entry.new }
   end
+
+  def register(
+        attribute:,
+        source:,
+        preprocessor:,
+        separator:,
+        allow_underscores:)
+    attribute         = (attribute || MuchSlug.default_attribute).to_s
+    source_proc       = source.to_proc
+    preprocessor_proc = (preprocessor || MuchSlug.default_preprocessor).to_proc
+    separator         = separator || MuchSlug.default_separator
+    allow_underscores =
+      if allow_underscores.nil?
+        MuchSlug.default_allow_underscores
+      else
+        !!allow_underscores
+      end
+
+    entry = self[attribute]
+    entry.source_proc       = source_proc
+    entry.preprocessor_proc = preprocessor_proc
+    entry.separator         = separator
+    entry.allow_underscores = allow_underscores
+
+    attribute
+  end
+
+  Entry =
+    Struct.new(
+      :source_proc,
+      :preprocessor_proc,
+      :separator,
+      :allow_underscores
+    )
 end

--- a/lib/much-slug/has_slug_registry.rb
+++ b/lib/much-slug/has_slug_registry.rb
@@ -14,21 +14,32 @@ module MuchSlug
           preprocessor:,
           separator:,
           allow_underscores:)
-      (attribute || MuchSlug.default_attribute).to_s.tap do |a|
+      attribute         = (attribute || MuchSlug.default_attribute).to_s
+      source_proc       = source.to_proc
+      preprocessor_proc = (preprocessor || MuchSlug.default_preprocessor).to_proc
+      separator         = separator || MuchSlug.default_separator
+      allow_underscores =
         if allow_underscores.nil?
-          allow_underscores = MuchSlug.default_allow_underscores
+          MuchSlug.default_allow_underscores
+        else
+          !!allow_underscores
         end
 
-        entry = self[a]
-        entry.source_proc       = source.to_proc
-        entry.preprocessor_proc = (preprocessor || MuchSlug.default_preprocessor).to_proc
-        entry.separator         = separator || MuchSlug.default_separator
-        entry.allow_underscores = !!allow_underscores
-      end
+      entry = self[attribute]
+      entry.source_proc       = source_proc
+      entry.preprocessor_proc = preprocessor_proc
+      entry.separator         = separator
+      entry.allow_underscores = allow_underscores
+
+      attribute
     end
 
-    class Entry
-      attr_accessor :source_proc, :preprocessor_proc, :separator, :allow_underscores
-    end
+    Entry =
+      Struct.new(
+        :source_proc,
+        :preprocessor_proc,
+        :separator,
+        :allow_underscores
+      )
   end
 end

--- a/lib/much-slug/slug.rb
+++ b/lib/much-slug/slug.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
-module MuchSlug
-  module Slug
-    def self.new(string, preprocessor:, separator:, allow_underscores: true)
-      regexp_escaped_sep = Regexp.escape(separator)
+module MuchSlug; end
 
-      slug = preprocessor.call(string.to_s.dup)
-      # Turn unwanted chars into the separator
-      slug.gsub!(/[^\w#{regexp_escaped_sep}]+/, separator)
-      # Turn underscores into the separator, unless allowing
-      slug.gsub!(/_/, separator) unless allow_underscores
-      # No more than one of the separator in a row.
-      slug.gsub!(/#{regexp_escaped_sep}{2,}/, separator)
-      # Remove leading/trailing separator.
-      slug.gsub!(/\A#{regexp_escaped_sep}|#{regexp_escaped_sep}\z/, "")
-      slug
-    end
+module MuchSlug::Slug
+  def self.new(string, preprocessor:, separator:, allow_underscores: true)
+    regexp_escaped_sep = Regexp.escape(separator)
+
+    slug = preprocessor.call(string.to_s.dup)
+    # Turn unwanted chars into the separator
+    slug.gsub!(/[^\w#{regexp_escaped_sep}]+/, separator)
+    # Turn underscores into the separator, unless allowing
+    slug.gsub!(/_/, separator) unless allow_underscores
+    # No more than one of the separator in a row.
+    slug.gsub!(/#{regexp_escaped_sep}{2,}/, separator)
+    # Remove leading/trailing separator.
+    slug.gsub!(/\A#{regexp_escaped_sep}|#{regexp_escaped_sep}\z/, "")
+    slug
   end
 end


### PR DESCRIPTION
This updates to automatically require the
`MuchSlug::ActiveRecord` mixin. This makes it so users don't have
to manually require in all the records they want to use it in.

This also includes a few style cleanups to the README code and
`MuchSlug` module.

# Other Changes

#### Updates and style cleanups to `ActiveRecord` and `HasSlugRegistry`

This is a small number of updates to the `ActiveRecord` mixin and
`HasSlugRegistry` class. This is mostly updating to our latest
style conventions. This includes making the
`much_slug_has_slug_registry` method on the `ActiveRecord` mixin
lazy and not set when the mixin is included.

#### Update module/class namespace style

This updates to not opening all of the namespace modules/classes
when defining sub-modules or sub-classes. This is part of our
latest conventions.