### PR TITLE
Update to work with STI records

### DIFF
--- a/lib/much-slug/activerecord.rb
+++ b/lib/much-slug/activerecord.rb
@@ -9,6 +9,13 @@ module MuchSlug::ActiveRecord
   include MuchMixin
 
   mixin_class_methods do
+    def inherited(child_class)
+      super
+      child_class.much_slug_has_slug_registry.copy_from(
+        much_slug_has_slug_registry,
+      )
+    end
+
     def much_slug_has_slug_registry
       @much_slug_has_slug_registry ||= MuchSlug::HasSlugRegistry.new
     end

--- a/lib/much-slug/has_slug_registry.rb
+++ b/lib/much-slug/has_slug_registry.rb
@@ -35,6 +35,12 @@ class MuchSlug::HasSlugRegistry < ::Hash
     attribute
   end
 
+  def copy_from(has_slug_registry)
+    has_slug_registry.each do |attribute, entry|
+      self[attribute] = entry.dup
+    end
+  end
+
   Entry =
     Struct.new(
       :source_proc,

--- a/test/unit/activerecord_tests.rb
+++ b/test/unit/activerecord_tests.rb
@@ -144,6 +144,26 @@ module MuchSlug::ActiveRecord
     end
   end
 
+  class ReceiverInheritedTests < ReceiverTests
+    desc "is inherited from"
+
+    setup do
+      subject.has_slug(source: :name)
+
+      Assert.stub_tap(MuchSlug::HasSlugRegistry, :new) do |has_slug_registry|
+        Assert.stub_on_call(has_slug_registry, :copy_from) do |call|
+          @has_slug_registry_copy_from_call = call
+        end
+      end
+    end
+
+    should "copy its MuchSlug::HasSlugRegistry to the child class" do
+      Class.new(receiver_class)
+      assert_that(@has_slug_registry_copy_from_call.args)
+        .equals([subject.much_slug_has_slug_registry])
+    end
+  end
+
   class ReceiverInitTests < ReceiverTests
     desc "when init"
     subject{ receiver }

--- a/test/unit/has_slug_registry_tests.rb
+++ b/test/unit/has_slug_registry_tests.rb
@@ -25,7 +25,7 @@ class MuchSlug::HasSlugRegistry
     let(:separator){ "|" }
     let(:allow_underscores){ Factory.boolean }
 
-    should have_imeths :register
+    should have_imeths :register, :copy_from
 
     should "default empty entries for unregisterd attributes" do
       assert_that(subject[Factory.string]).is_an_instance_of(unit_class::Entry)
@@ -71,6 +71,45 @@ class MuchSlug::HasSlugRegistry
       assert_that(entry.separator).equals(MuchSlug.default_separator)
       assert_that(entry.allow_underscores)
         .equals(MuchSlug.default_allow_underscores)
+    end
+  end
+
+  class CopyFromTests < InitTests
+    desc "#copy_from"
+
+    setup do
+      parent_has_slug_registry.register(
+        attribute: attribute,
+        source: source,
+        preprocessor: nil,
+        separator: nil,
+        allow_underscores: nil,
+      )
+      parent_has_slug_registry.register(
+        attribute: other_attribute,
+        source: other_source,
+        preprocessor: nil,
+        separator: nil,
+        allow_underscores: nil,
+      )
+    end
+
+    let(:other_attribute){ Factory.symbol }
+    let(:other_source){ :to_s }
+
+    let(:parent_has_slug_registry){ unit_class.new }
+
+    should "copy entries from the passed MuchSlug::HasSlugRegistry" do
+      subject.copy_from(parent_has_slug_registry)
+
+      assert_that(subject[attribute])
+        .equals(parent_has_slug_registry[attribute])
+      assert_that(subject[attribute])
+        .is_not(parent_has_slug_registry[attribute])
+      assert_that(subject[other_attribute])
+        .equals(parent_has_slug_registry[other_attribute])
+      assert_that(subject[other_attribute])
+        .is_not(parent_has_slug_registry[other_attribute])
     end
   end
 


### PR DESCRIPTION
This updates the `MuchSlug::ActiveRecord` to have an `inherited`
hook that copies registry entries to any classes that inherit
from it. This makes it so a `has_slug` configuration can be set
in a base class but still take effect in a child class. Without
this, any child classes will not run the logic to generate their
slug and will leave it blank.
